### PR TITLE
Implement delete_instance_callback

### DIFF
--- a/classes/local/catmodel/instance/instance_actions_handler.php
+++ b/classes/local/catmodel/instance/instance_actions_handler.php
@@ -17,7 +17,6 @@
 namespace adaptivequizcatmodel_catquiz\local\catmodel\instance;
 
 use local_catquiz\catquiz_handler;
-use local_catquiz\testenvironment;
 use mod_adaptivequiz\local\catmodel\instance\catmodel_add_instance_handler;
 use mod_adaptivequiz\local\catmodel\instance\catmodel_delete_instance_handler;
 use mod_adaptivequiz\local\catmodel\instance\catmodel_update_instance_handler;
@@ -69,19 +68,13 @@ class instance_actions_handler implements
      */
     public function delete_instance_callback(stdClass $adaptivequiz): void {
         global $DB;
-
-        // Create stdClass with all the values.
-        $cattest = (object)[
-            'componentid' => $adaptivequiz->id,
-            'component' => 'mod_adaptivequiz',
-            'json' => json_encode($adaptivequiz),
-            'status' => 0, // 0 Stands for deleted.
-        ];
-
-        // Pass on the values as stdClas.
-        $test = new testenvironment($cattest);
-
-        // Save the values in the DB.
-        $test->save_or_update();
+        $DB->delete_records(
+            'local_catquiz_tests',
+            ['componentid' => $adaptivequiz->id, 'component' => 'mod_adaptivequiz']
+        );
+        $DB->delete_records(
+            'local_catquiz_attempts',
+            ['instanceid' => $adaptivequiz->id, 'component' => 'adaptivequiz']
+        );
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024041600;
+$plugin->version = 2024062800;
 $plugin->release = '1.0.1';
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->requires = 2022041900;


### PR DESCRIPTION
If an adaptive quiz is deleted, we now also delete the values stored by the catquiz plugin:

- The `local_catquiz_tests` entry for the corresponding test is removed
- The attempts for the given quiz are removed from `local_catquiz_attempts`