### PR TITLE
Delete progress entries in delete callback

### DIFF
--- a/classes/local/catmodel/instance/instance_actions_handler.php
+++ b/classes/local/catmodel/instance/instance_actions_handler.php
@@ -72,9 +72,29 @@ class instance_actions_handler implements
             'local_catquiz_tests',
             ['componentid' => $adaptivequiz->id, 'component' => 'mod_adaptivequiz']
         );
-        $DB->delete_records(
+
+        $attemptids = $DB->get_fieldset_select(
             'local_catquiz_attempts',
+            'attemptid',
+            'instanceid = :instanceid AND component = :component',
             ['instanceid' => $adaptivequiz->id, 'component' => 'adaptivequiz']
+        );
+
+        // If there are no attempts to delete, we can return.
+        if (!$attemptids) {
+            return;
+        }
+
+        [$insql, $inparams] = $DB->get_in_or_equal($attemptids);
+        $DB->delete_records_select(
+            'local_catquiz_progress',
+            "attemptid {$insql}",
+            $inparams
+        );
+        $DB->delete_records_select(
+            'local_catquiz_attempts',
+            "attemptid {$insql}",
+            $inparams
         );
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024123105;
+$plugin->version = 2024123106;
 $plugin->release = '1.0.3';
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->requires = 2022041900;


### PR DESCRIPTION
See issue #662 in local_catquiz: when an attempt is deleted, we should also delete the respective data from the progress.